### PR TITLE
fix: remove isReturnHttpResponse check on imports merging

### DIFF
--- a/packages/mock/src/msw/index.ts
+++ b/packages/mock/src/msw/index.ts
@@ -155,19 +155,18 @@ export const ${handlerName} = (overrideResponse?: ${returnType} | ((${infoParam}
   })
 }\n`;
 
-  const includeResponseImports =
-    isReturnHttpResponse && !isTextPlain
-      ? [
-          ...imports,
-          ...response.imports.filter((r) => {
-            // Only include imports which are actually used in mock.
-            const reg = new RegExp(`\\b${r.name}\\b`);
-            return (
-              reg.test(handlerImplementation) || reg.test(mockImplementation)
-            );
-          }),
-        ]
-      : imports;
+  const includeResponseImports = !isTextPlain
+    ? [
+        ...imports,
+        ...response.imports.filter((r) => {
+          // Only include imports which are actually used in mock.
+          const reg = new RegExp(`\\b${r.name}\\b`);
+          return (
+            reg.test(handlerImplementation) || reg.test(mockImplementation)
+          );
+        }),
+      ]
+    : imports;
 
   return {
     implementation: {


### PR DESCRIPTION
Simplifies the `includeResponseImports` logic by removing the unnecessary `isReturnHttpResponse` condition.